### PR TITLE
Remove DEPRECATED event

### DIFF
--- a/client/simple-contract/src/context/Web3Provider.js
+++ b/client/simple-contract/src/context/Web3Provider.js
@@ -37,8 +37,8 @@ const Web3Provider = props => {
               setCurrentAccount(accounts[0])
             });
             //Detect metamask network ID change
-            window.ethereum.on('networkChanged', function(networkId){
-              // console.log('networkChanged',networkId);
+            window.ethereum.on('chainChanged', function(networkId){
+              // console.log('chainChanged',networkId);
               setCurrentNetworkID(parseInt(networkId));
             });
           } else {


### PR DESCRIPTION
MetaMask: The event 'networkChanged' is deprecated and may be removed in the future. Use 'chainChanged' instead.
For more information, see: https://eips.ethereum.org/EIPS/eip-1193#chainchanged and https://docs.metamask.io/guide/ethereum-provider.html#networkchanged-deprecated